### PR TITLE
Changing client.Capture/NewPacket to client.CaptureMessage

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -21,21 +21,17 @@ func Recovery(client *raven.Client, onlyCrashes bool) gin.HandlerFunc {
 			if rval := recover(); rval != nil {
 				debug.PrintStack()
 				rvalStr := fmt.Sprint(rval)
-				packet := raven.NewPacket(rvalStr,
-					raven.NewException(errors.New(rvalStr), raven.NewStacktrace(2, 3, nil)),
+				client.CaptureMessage(rvalStr, flags, raven.NewException(errors.New(rvalStr), raven.NewStacktrace(2, 3, nil)),
 					raven.NewHttp(c.Request))
-				client.Capture(packet, flags)
 				c.AbortWithStatus(http.StatusInternalServerError)
 			}
 			if !onlyCrashes {
 				for _, item := range c.Errors {
-					packet := raven.NewPacket(item.Error(),
-						&raven.Message{
-							Message: item.Error(),
-							Params:  []interface{}{item.Meta},
-						},
+					client.CaptureMessage(item.Error(), flags, &raven.Message{
+						Message: item.Error(),
+						Params:  []interface{}{item.Meta},
+					},
 						raven.NewHttp(c.Request))
-					client.Capture(packet, flags)
 				}
 			}
 		}()


### PR DESCRIPTION
This patch changes push of new message to Sentry to the generic
CaptureMessage function, which allow us to send client.context
interfaces to Sentry server (UserContext, HttpContext, TagsContext).

Signed-off-by: Romain Beuque <romain.beuque@corp.ovh.com>