### PR TITLE
fix: invalid character in source code

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/getsentry/raven-go"｀
+	"github.com/getsentry/raven-go"
 	"github.com/gin-contrib/sentry"
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
can't load package: package github.com/gin-contrib/sentry/example: 
github.com/gin-contrib/sentry/example/main.go:4:33: illegal character U+FF40 '｀'
github.com/gin-contrib/sentry/example/main.go:8:2: expected ')', found 'EOF'
